### PR TITLE
Don't install files as executable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,14 @@ DOCDIR=/usr/share/doc/hwids
 
 install-base: compress
 	mkdir -p $(DESTDIR)$(DOCDIR)
-	install -p README.md $(DESTDIR)$(DOCDIR)
+	install -p -m 644 README.md $(DESTDIR)$(DOCDIR)
 	mkdir -p $(DESTDIR)$(MISCDIR)
 	for file in usb.ids pci.ids usb.ids.gz pci.ids.gz oui.txt iab.txt; do \
-		install -p $$file $(DESTDIR)$(MISCDIR); \
+		install -p -m 644 $$file $(DESTDIR)$(MISCDIR); \
 	done
 
 install-hwdb:
 	mkdir -p $(DESTDIR)$(HWDBDIR)
 	for file in udev/*.hwdb; do \
-		install -p $$file $(DESTDIR)$(HWDBDIR); \
+		install -p -m 644 $$file $(DESTDIR)$(HWDBDIR); \
 	done


### PR DESCRIPTION
`install` by default installs files with executable bit set, which is pointless for data files. Add `-m 644` to the command line.
