### PR TITLE
Added 24ae:2000 device description

### DIFF
--- a/usb.ids
+++ b/usb.ids
@@ -18470,6 +18470,8 @@
 248a  Maxxter
 	8366  Wireless Optical Mouse ACT-MUSW-002
 249c  M2Tech s.r.l.
+24ae  RAPOO
+	2000  RAPOO 2.4G Wireless Device
 24e1  Paratronic
 	3001  Adp-usb
 	3005  Radius


### PR DESCRIPTION
Data from **/proc/bus/input/devices**:

> I: Bus=0003 Vendor=24ae Product=2000 Version=0101
> N: Name="RAPOO RAPOO 2.4G Wireless Device"
> P: Phys=usb-0000:00:14.0-4.4.2/input1
> S: Sysfs=/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4.4/1-4.4.2/1-4.4.2:1.1/0003:24AE:2000.000F/input/input19
> U: Uniq=
> H: Handlers=kbd event4 mouse0 
> B: PROP=0
> B: EV=1f
> B: KEY=3f0003007f 0 0 483ffff17aff32d bf54444600000000 1f0001 130f938b17c000 677bfad941dfed 9ed68000004400 10000002
> B: REL=1c3
> B: ABS=100000000
> B: MSC=10
> 
> I: Bus=0003 Vendor=24ae Product=2000 Version=0101
> N: Name="RAPOO RAPOO 2.4G Wireless Device"
> P: Phys=usb-0000:00:14.0-4.4.2/input0
> S: Sysfs=/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4.4/1-4.4.2/1-4.4.2:1.0/0003:24AE:2000.0010/input/input20
> U: Uniq=
> H: Handlers=sysrq kbd event13 leds 
> B: PROP=0
> B: EV=120013
> B: KEY=1000000000007 ff9f207ac14057ff febeffdfffefffff fffffffffffffffe
> B: MSC=10
> B: LED=1f
